### PR TITLE
Fixed custom exception classloading issue

### DIFF
--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/MappingExceptionListener.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/MappingExceptionListener.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.mule.module.apikit.exception.ApikitRuntimeException;
+import org.mule.util.ClassUtils;
 
 public class MappingExceptionListener extends CatchMessagingExceptionStrategy
 {
@@ -34,7 +35,7 @@ public class MappingExceptionListener extends CatchMessagingExceptionStrategy
         {
             try
             {
-                this.exceptions.add(Class.forName(exception));
+                this.exceptions.add(ClassUtils.getClass(exception));
             }
             catch (ClassNotFoundException e)
             {


### PR DESCRIPTION
When using Class.forName and APIKit deployed as a plugin it uses another classloader and it does not find classes provided in the user's app.

This change takes this into account so custom exceptions are found.
