### PR TITLE
Fix Console port handling behind a reverse proxy.

### DIFF
--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/ConsoleHandler.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/ConsoleHandler.java
@@ -126,10 +126,6 @@ public class ConsoleHandler
             {
                 path = RESOURCE_BASE + "/index.html";
                 String host = event.getMessage().getInboundProperty("host");
-                if (host.contains(":"))
-                {
-                    host = host.split(":")[0];
-                }
                 in = new ByteArrayInputStream(getHomePage(host).getBytes());
             }
             else if (path.startsWith(consolePath))
@@ -173,11 +169,17 @@ public class ConsoleHandler
             return homePage.get(baseHost);
         }
 
-        String page = homePage.get(host);
+        String hostPart = host;
+        if (host.contains(":"))
+        {
+            hostPart = host.split(":")[0];
+        }
+
+        String page = homePage.get(hostPart);
         if (page == null)
         {
-            page = homePage.get(baseHost).replace(BIND_ALL_HOST, host);
-            homePage.put(host, page);
+            page = homePage.get(baseHost).replaceAll(BIND_ALL_HOST + "(:[0-9]*)*", host);
+            homePage.put(hostPart, page);
         }
         return page;
     }


### PR DESCRIPTION
If Mule is run behind a reverse proxy on a different port than on the reverse
proxy the console application will not work as it presents the Mule port
(instead of the reverse proxy port) to the browser.

This patch uses the **BIND_ALL_HOST** mechanism to also set the port to the
requested / reverse proxy port in the console page.
