### PR TITLE
Fix for issue APIKIT-282.

### DIFF
--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/UrlUtils.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/UrlUtils.java
@@ -17,7 +17,16 @@ public class UrlUtils
 
     public static String getBaseSchemeHostPort(MuleEvent event)
     {
-        String host = event.getMessage().getInboundProperty("host");
+        String host;
+        String chHost = System.getProperty("fullDomain");
+        if (chHost != null)
+        {
+            host = chHost;
+        }
+        else
+        {
+            host = event.getMessage().getInboundProperty("host");
+        }
         String endpoint = event.getMessage().getInboundProperty("http.context.uri");
         String scheme;
         if (endpoint.startsWith("http:"))


### PR DESCRIPTION
- Added a condition to getBaseSchemeHostPort method to allow finding the CH URI (w/o port) in the homePage HashMap.
