### PR TITLE
Adding muleVersion to scaffolder

### DIFF
--- a/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/Scaffolder.java
+++ b/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/Scaffolder.java
@@ -9,6 +9,7 @@ package org.mule.tools.apikit;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
+import org.mule.tools.apikit.misc.APIKitTools;
 import org.mule.tools.apikit.model.APIFactory;
 import org.mule.tools.apikit.output.GenerationModel;
 import org.mule.tools.apikit.output.GenerationStrategy;
@@ -25,18 +26,31 @@ public class Scaffolder {
     private final MuleConfigGenerator muleConfigGenerator;
 
     public static Scaffolder createScaffolder(Log log, File muleXmlOutputDirectory,
-                                   List<String> specFiles, List<String> muleXmlFiles)
+                                              List<String> specFiles, List<String> muleXmlFiles)
+            throws MojoExecutionException
+    {
+        return createScaffolder(log, muleXmlOutputDirectory, specFiles, muleXmlFiles, null);
+    }
+
+    public static Scaffolder createScaffolder(Log log, File muleXmlOutputDirectory,
+                                   List<String> specFiles, List<String> muleXmlFiles, String muleVersion)
             throws MojoExecutionException {
         FileListUtils fileUtils = new FileListUtils(log);
 
         Map<File, InputStream> fileInputStreamMap = fileUtils.toStreamsOrFail(specFiles);
         Map<File, InputStream> streams = fileUtils.toStreamsOrFail(muleXmlFiles);
 
-        return new Scaffolder(log, muleXmlOutputDirectory, fileInputStreamMap, streams);
+        return new Scaffolder(log, muleXmlOutputDirectory, fileInputStreamMap, streams, muleVersion);
     }
 
     public Scaffolder(Log log, File muleXmlOutputDirectory,  Map<File, InputStream> ramls,
                       Map<File, InputStream> xmls)  {
+        this(log,muleXmlOutputDirectory,ramls, xmls, null);
+    }
+
+    public Scaffolder(Log log, File muleXmlOutputDirectory,  Map<File, InputStream> ramls,
+                      Map<File, InputStream> xmls, String muleVersion)  {
+        APIKitTools.chooseInboundCreation(muleVersion);
         APIFactory apiFactory = new APIFactory();
         RAMLFilesParser RAMLFilesParser = new RAMLFilesParser(log, ramls, apiFactory);
         MuleConfigParser muleConfigParser = new MuleConfigParser(log, ramls.keySet(), xmls, apiFactory);

--- a/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/ScaffolderAPI.java
+++ b/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/ScaffolderAPI.java
@@ -29,12 +29,12 @@ public class ScaffolderAPI {
      * @param ramlFiles the ramlFiles to which the scaffolder will be run on
      * @param appDir the directory which contained the generated Mule config files
      */
-    public void run(List<File> ramlFiles, File appDir) {
+    public void run(List<File> ramlFiles, File appDir, String muleVersion) {
         List<String> ramlFilePaths = retrieveFilePaths(ramlFiles, apiExtensions);
         List<String> muleXmlFiles = retrieveFilePaths(appDir, appExtensions);
         Scaffolder scaffolder;
         try {
-            scaffolder = Scaffolder.createScaffolder(new SystemStreamLog(), appDir, ramlFilePaths, muleXmlFiles);
+            scaffolder = Scaffolder.createScaffolder(new SystemStreamLog(), appDir, ramlFilePaths, muleXmlFiles, muleVersion);
         } catch(Exception e) {
             throw new RuntimeException("Error executing scaffolder", e);
         }

--- a/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/misc/APIKitTools.java
+++ b/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/misc/APIKitTools.java
@@ -6,6 +6,7 @@
  */
 package org.mule.tools.apikit.misc;
 
+import org.apache.commons.lang.StringUtils;
 import org.jdom2.Namespace;
 
 import org.mule.tools.apikit.model.API;
@@ -18,6 +19,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class APIKitTools {
+    private static final String MULE_VERSION_WITH_LISTENERS = "360";
+    private static Boolean forcedToUseInboundEndpoint = false;
     public static final NamespaceWithLocation API_KIT_NAMESPACE = new NamespaceWithLocation(
             Namespace.getNamespace("apikit", "http://www.mulesoft.org/schema/mule/apikit"),
             "http://www.mulesoft.org/schema/mule/apikit/current/mule-apikit.xsd"
@@ -117,5 +120,27 @@ public class APIKitTools {
             path = path.replace("//","/");
         }
         return path;
+    }
+
+    public static void chooseInboundCreation(String muleVersion){
+        if (muleVersion == null){
+            forcedToUseInboundEndpoint = false;
+            return;
+        }
+        muleVersion = muleVersion.replace("-","").replace("SNAPSHOT","").replace(".","").replace("BETA","");
+        String muleVersionWithListeners = MULE_VERSION_WITH_LISTENERS;
+        int digitsDifference = muleVersion.length() - muleVersionWithListeners.length();
+        if (digitsDifference > 0){
+            muleVersionWithListeners = muleVersionWithListeners.concat(StringUtils.repeat("0", digitsDifference));
+        }
+        else if (digitsDifference < 0){
+            muleVersion = muleVersion.concat(StringUtils.repeat("0", digitsDifference * -1));
+        }
+        forcedToUseInboundEndpoint = (Integer.parseInt(muleVersion) < Integer.parseInt(muleVersionWithListeners));
+    }
+
+    public static Boolean isForcedToUseInboundEndpoint()
+    {
+        return forcedToUseInboundEndpoint;
     }
 }

--- a/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/model/API.java
+++ b/apikit-tools/apikit-maven-plugin/src/main/java/org/mule/tools/apikit/model/API.java
@@ -103,6 +103,10 @@ public class API {
 
     public Boolean useInboundEndpoint()
     {
+        if (APIKitTools.isForcedToUseInboundEndpoint())
+        {
+            return true;
+        }
         return useInboundEndpoint;
     }
     public boolean setUseInboundEndpoint(Boolean useInboundEndpoint)

--- a/apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/APIKitToolsTest.java
+++ b/apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/APIKitToolsTest.java
@@ -6,6 +6,9 @@
  */
 package org.mule.tools.apikit;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.mule.tools.apikit.misc.APIKitTools;
 import org.mule.tools.apikit.model.API;
 
@@ -36,5 +39,25 @@ public class APIKitToolsTest
         Assert.assertEquals("/path/path2/*", APIKitTools.getPathFromUri(uri,true));
         Assert.assertEquals("/path/path2/", APIKitTools.getPathFromUri(uri,false));
 
+    }
+
+    @Test
+    public void isForcedToCreateInboundEndpointsTest(){
+        APIKitTools.chooseInboundCreation("3.5.0");
+        assertTrue(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation("3.6.0");
+        assertFalse(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation("3.5.1-SNAPSHOT");
+        assertTrue(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation("3.5.1-BETA");
+        assertTrue(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation("3.6.0-SNAPSHOT");
+        assertFalse(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation("3.6.1");
+        assertFalse(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation("3.5.11");
+        assertTrue(APIKitTools.isForcedToUseInboundEndpoint());
+        APIKitTools.chooseInboundCreation(null);
+        assertFalse(APIKitTools.isForcedToUseInboundEndpoint());
     }
 }

--- a/apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/ScaffolderTest.java
+++ b/apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/ScaffolderTest.java
@@ -66,6 +66,22 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testTwoResourceGenerateForcingInboundEndpoints() throws Exception {
+        File muleXmlSimple = simpleGeneration("two","3.5.1");
+        assertTrue(muleXmlSimple.exists());
+        String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
+
+        assertEquals(1, countOccurences(s, "get:/pet:two-config"));
+        assertEquals(1, countOccurences(s, "post:/pet:two-config"));
+
+        assertEquals(1, countOccurences(s, "get:/car:two-config"));
+        assertEquals(1, countOccurences(s, "post:/car:two-config"));
+        assertEquals(0, countOccurences(s, "http:listener "));
+        assertEquals(0, countOccurences(s, "http:listener-config "));
+        assertEquals(1, countOccurences(s, "http:inbound-endpoint "));
+    }
+
+    @Test
     public void testNestedGenerate() throws Exception {
         File muleXmlSimple = simpleGeneration("nested");
         assertTrue(muleXmlSimple.exists());
@@ -77,6 +93,31 @@ public class ScaffolderTest {
 
         assertEquals(1, countOccurences(s, "get:/car:nested-config"));
         assertEquals(1, countOccurences(s, "post:/car:nested-config"));
+        assertEquals(1, countOccurences(s, "http:listener "));
+        assertEquals(1, countOccurences(s, "http:listener-config "));
+        assertEquals(0, countOccurences(s, "http:inbound-endpoint "));
+
+
+    }
+
+    @Test
+    public void testNestedGenerateForcingInboundEndpoints() throws Exception {
+        File muleXmlSimple = simpleGeneration("nested","3.4.3");
+        assertTrue(muleXmlSimple.exists());
+        String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
+
+        assertEquals(1, countOccurences(s, "get:/pet:nested-config"));
+        assertEquals(1, countOccurences(s, "post:/pet:nested-config"));
+        assertEquals(1, countOccurences(s, "get:/pet/owner:nested-config"));
+
+        assertEquals(1, countOccurences(s, "get:/car:nested-config"));
+        assertEquals(1, countOccurences(s, "post:/car:nested-config"));
+        assertEquals(1, countOccurences(s, "http:inbound-endpoint"));
+        assertEquals(0, countOccurences(s, "http:listener "));
+        assertEquals(0, countOccurences(s, "http:listener-config "));
+
+
+
     }
 
     @Test
@@ -86,11 +127,32 @@ public class ScaffolderTest {
         String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
         assertEquals(1, countOccurences(s, "http:listener-config name=\"no-name-httpListenerConfig\" host=\"localhost\" port=\"8081\""));
         assertEquals(1, countOccurences(s, "http:listener config-ref=\"no-name-httpListenerConfig\" path=\"/api/*\""));
+        assertEquals(0, countOccurences(s, "http:inbound-endpoint"));
+
+    }
+
+    @Test
+    public void testNoNameGenerateForcingInboundEndpoints() throws Exception {
+        File muleXmlSimple = simpleGeneration("no-name","3.4.5");
+        assertTrue(muleXmlSimple.exists());
+        String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
+        assertEquals(0, countOccurences(s, "http:listener-config "));
+        assertEquals(0, countOccurences(s, "http:listener "));
+        assertEquals(1, countOccurences(s, "http:inbound-endpoint "));
     }
 
     @Test
     public void testExampleGenerate() throws Exception {
         File muleXmlSimple = simpleGeneration("example");
+        assertTrue(muleXmlSimple.exists());
+        String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
+
+        assertEquals(1, countOccurences(s, "{&#xA;    &quot;name&quot;: &quot;Bobby&quot;,&#xA;    &quot;food&quot;: &quot;Ice Cream&quot;&#xA;}"));
+    }
+
+    @Test
+    public void testExampleGenerateForcingInboundEndpoints() throws Exception {
+        File muleXmlSimple = simpleGeneration("example", "3.5.0");
         assertTrue(muleXmlSimple.exists());
         String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
 
@@ -129,8 +191,8 @@ public class ScaffolderTest {
 
         assertTrue(xmlFile.exists());
         String s = IOUtils.toString(new FileInputStream(xmlFile));
-        assertEquals(0, countOccurences(s, "http:listener-config"));
-        assertEquals(0, countOccurences(s, "http:listener"));
+        assertEquals(0, countOccurences(s, "http:listener-config "));
+        assertEquals(0, countOccurences(s, "http:listener "));
         assertEquals(1, countOccurences(s, "http:inbound-endpoint port=\"${serverPort}\" host=\"localhost\" path=\"api\""));
 
 
@@ -150,8 +212,8 @@ public class ScaffolderTest {
 
         assertTrue(xmlFile.exists());
         String s = IOUtils.toString(new FileInputStream(xmlFile));
-        assertEquals(0, countOccurences(s, "http:listener-config"));
-        assertEquals(0, countOccurences(s, "http:listener"));
+        assertEquals(0, countOccurences(s, "http:listener-config "));
+        assertEquals(0, countOccurences(s, "http:listener "));
         assertEquals(1, countOccurences(s, "http:inbound-endpoint address"));
 
         assertEquals(1, countOccurences(s, "put:/clients/{clientId}:complex-config"));
@@ -232,6 +294,16 @@ public class ScaffolderTest {
         return new Scaffolder(log, muleXmlOut, ramlMap, xmlMap);
     }
 
+    private Scaffolder createScaffolder(List<File> ramls, List<File> xmls, File muleXmlOut, String muleVersion)
+            throws MojoExecutionException {
+        Log log = mock(Log.class);
+
+        Map<File, InputStream> ramlMap = getFileInputStreamMap(ramls);
+        Map<File, InputStream> xmlMap = getFileInputStreamMap(xmls);
+
+        return new Scaffolder(log, muleXmlOut, ramlMap, xmlMap, muleVersion);
+    }
+
     private Map<File, InputStream> getFileInputStreamMap(List<File> ramls) {
         return fileListUtils.toStreamFromFiles(ramls);
     }
@@ -256,4 +328,14 @@ public class ScaffolderTest {
         return new File(muleXmlOut, name + ".xml");
     }
 
+    private File simpleGeneration(String name, String muleVersion) throws Exception {
+        List<File> ramls = Arrays.asList(getFile("scaffolder/" + name + ".raml"));
+        List<File> xmls = Arrays.asList();
+        File muleXmlOut = folder.newFolder("mule-xml-out");
+
+        Scaffolder scaffolder = createScaffolder(ramls, xmls, muleXmlOut, muleVersion);
+        scaffolder.run();
+
+        return new File(muleXmlOut, name + ".xml");
+    }
 }


### PR DESCRIPTION
ScaffolderAPI.run() has a new parameter: muleVersion. 
- If muleVersion is null, it means that the scaffolder will use listeners (because it is not forced to use inbound-endpoints)