### PR TITLE
Fixing SE-1852: RAML designer out of sync with Anypoint Studio.

### DIFF
--- a/apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/input/RAMLFilesParserTest.java
+++ b/apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/input/RAMLFilesParserTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tools.apikit.input;
+
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Test;
+import org.mule.tools.apikit.model.APIFactory;
+import org.mule.tools.apikit.model.ResourceActionMimeTypeTriplet;
+import org.mule.tools.apikit.output.GenerationModel;
+
+public class RAMLFilesParserTest
+{
+
+    @Test
+    public void apiWithWarningsShouldBeValid()
+    {
+        final InputStream resourceAsStream =
+                RAMLFilesParserTest.class.getClassLoader().getResourceAsStream(
+                        "scaffolder/apiWithWarnings.raml");
+        
+        Log log = mock(Log.class);
+
+        HashSet<File> ramlPaths = new HashSet<File>();
+        ramlPaths.add(new File("leagues.raml"));
+
+        HashMap<File, InputStream> streams = new HashMap<File, InputStream>();
+        streams.put(new File("hello"), resourceAsStream);
+
+        RAMLFilesParser ramlFilesParser = new RAMLFilesParser(log, streams, new APIFactory());
+
+        Map<ResourceActionMimeTypeTriplet, GenerationModel> entries = ramlFilesParser.getEntries();
+        assertNotNull(entries);
+        assertEquals(1, entries.size());
+    }
+    
+}

--- a/apikit-tools/apikit-maven-plugin/src/test/resources/scaffolder/apiWithWarnings.raml
+++ b/apikit-tools/apikit-maven-plugin/src/test/resources/scaffolder/apiWithWarnings.raml
@@ -1,0 +1,31 @@
+#%RAML 0.8
+---
+title: Sample API
+version: v0.1
+protocols: [HTTP]
+baseUri: http://localhost:9090/api/{version}
+/items:
+  displayName: Items
+  get:
+    description: Get a list of all the available items. 
+    queryParameters:
+      size:
+        displayName: Size
+        description: |
+          Size of the item. 
+        enum: [ small, medium, large ]
+        required: false
+        default: ""
+      color:
+        displayName: Color
+        description: |
+          Color of the item. 
+        enum: [ blue, yellow ]
+        required: false
+        default: ""
+    responses:
+            200:
+                body:
+                    application/json: !!null
+                    text/xml: !!null
+                    


### PR DESCRIPTION
RAML files which contains warnings must be handled as valid files.

Conflicts:
	apikit-tools/apikit-maven-plugin/src/test/java/org/mule/tools/apikit/input/RAMLFilesParserTest.java