### PR TITLE
APIKIT-514: Changing scaffolder to use different parser versions according to the raml first line. 

### DIFF
--- a/apikit-tools/apikit-scaffolder/pom.xml
+++ b/apikit-tools/apikit-scaffolder/pom.xml
@@ -63,7 +63,13 @@
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-module-apikit-spi</artifactId>
             <version>${project.version}</version>
-       </dependency>   
+       </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/apikit-tools/apikit-scaffolder/pom.xml
+++ b/apikit-tools/apikit-scaffolder/pom.xml
@@ -16,6 +16,11 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.raml</groupId>
+            <artifactId>parser-interface-impl-v1</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.raml</groupId>
             <artifactId>parser-interface-impl-v2</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/apikit-tools/apikit-scaffolder/src/main/java/org/mule/tools/apikit/model/APIFactory.java
+++ b/apikit-tools/apikit-scaffolder/src/main/java/org/mule/tools/apikit/model/APIFactory.java
@@ -7,7 +7,11 @@
 package org.mule.tools.apikit.model;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.Validate;
@@ -55,7 +59,7 @@ public class APIFactory
             {
                 if (domainHttpListenerConfigs.size() >0)
                 {
-                    api.setHttpListenerConfig(domainHttpListenerConfigs.values().iterator().next());
+                    api.setHttpListenerConfig(getFirstLC());
                 }
                 else
                 {
@@ -74,5 +78,20 @@ public class APIFactory
 
     public Map<String, HttpListenerConfig> getDomainHttpListenerConfigs() {
         return domainHttpListenerConfigs;
+    }
+
+    private HttpListenerConfig getFirstLC()
+    {
+        List<Map.Entry<String,HttpListenerConfig>> list = new ArrayList<>(domainHttpListenerConfigs.entrySet());
+        Collections.sort(list, new Comparator<Map.Entry<String, HttpListenerConfig>>(){
+            @Override
+            public int compare(Map.Entry<String, HttpListenerConfig> o1, Map.Entry<String, HttpListenerConfig> o2)
+            {
+                Integer i1 = Integer.parseInt(o1.getValue().getPort());
+                Integer i2 = Integer.parseInt(o2.getValue().getPort());
+                return i1.compareTo(i2);
+            }
+        });
+        return list.get(0).getValue();
     }
 }

--- a/apikit-tools/apikit-scaffolder/src/test/java/org/mule/tools/apikit/ScaffolderTest.java
+++ b/apikit-tools/apikit-scaffolder/src/test/java/org/mule/tools/apikit/ScaffolderTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mule.tools.apikit.Helper.countOccurences;
 
+import org.mule.raml.implv2.ParserV2Utils;
 import org.mule.tools.apikit.misc.FileListUtils;
 
 import java.io.File;
@@ -29,6 +30,7 @@ import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.logging.Log;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,7 +41,6 @@ public class ScaffolderTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
     private FileListUtils fileListUtils = new FileListUtils();
-
 
     @Before
     public void setUp() {
@@ -79,6 +80,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithExtensionWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithExtension();
+    }
+
+    @Test
+    public void testSimpleGenerateWithExtensionWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithExtension();
+    }
+
     public void testSimpleGenerateWithExtension() throws Exception {
         File muleXmlFolderOut = simpleGenerationWithExtensionEnabled("simple", "simple", null, "3.8.0");
         File xmlOut = new File (muleXmlFolderOut, "simple.xml");
@@ -91,6 +104,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithExtensionInNullWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithExtension();
+    }
+
+    @Test
+    public void testSimpleGenerateWithExtensionInNullWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithExtension();
+    }
+
     public void testSimpleGenerateWithExtensionInNull() throws Exception {
         File muleXmlFolderOut = simpleGenerationWithExtensionEnabled("simple", null, null, "3.8.0");
         File xmlOut = new File (muleXmlFolderOut, "simple.xml");
@@ -103,6 +128,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithInboundEndpointWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithInboundEndpoint();
+    }
+
+    @Test
+    public void testSimpleGenerateWithInboundEndpointWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithInboundEndpoint();
+    }
+
     public void testSimpleGenerateWithInboundEndpoint() throws Exception {
         File xmlOut = simpleGeneration("simple", null, "3.5.0");
         assertTrue(xmlOut.exists());
@@ -115,6 +152,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithListenerWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithListener();
+    }
+
+    @Test
+    public void testSimpleGenerateWithListenerWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithListener();
+    }
+
     public void testSimpleGenerateWithListener() throws Exception {
         File xmlOut = simpleGeneration("simple", null, "3.6.0");
         assertTrue(xmlOut.exists());
@@ -127,6 +176,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithListenerAndExtensionWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithListenerAndExtension();
+    }
+
+    @Test
+    public void testSimpleGenerateWithListenerAndExtensionWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithListenerAndExtension();
+    }
+
     public void testSimpleGenerateWithListenerAndExtension() throws Exception {
         File muleXmlFolderOut = simpleGenerationWithExtensionEnabled("simple", "simple", null, "3.8.0");
         File xmlOut = new File (muleXmlFolderOut, "simple.xml");
@@ -139,8 +200,19 @@ public class ScaffolderTest {
         assertEquals(1, countOccurences(s, "extensionEnabled"));
     }
 
+    @Test
+    public void testSimpleGenerateWithCustomDomainWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithCustomDomain();
+    }
 
     @Test
+    public void testSimpleGenerateWithCustomDomainWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithCustomDomain();
+    }
+
     public void testSimpleGenerateWithCustomDomain() throws Exception {
         File muleXmlSimple = simpleGeneration("simple", "custom-domain/mule-domain-config.xml",null);
         assertTrue(muleXmlSimple.exists());
@@ -153,6 +225,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithCustomDomainAndExtensionWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithCustomDomainAndExtension();
+    }
+
+    @Test
+    public void testSimpleGenerateWithCustomDomainAndExtensionWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithCustomDomainAndExtension();
+    }
+
     public void testSimpleGenerateWithCustomDomainAndExtension() throws Exception {
         File muleXmlFolderOut = simpleGenerationWithExtensionEnabled("simple", "simple", "custom-domain/mule-domain-config.xml", "3.8.0");
         File xmlOut = new File (muleXmlFolderOut, "simple.xml");
@@ -166,6 +250,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithCustomDomainWithMultipleLCWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithCustomDomainWithMultipleLC();
+    }
+
+    @Test
+    public void testSimpleGenerateWithCustomDomainWithMultipleLCWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithCustomDomainWithMultipleLC();
+    }
+
     public void testSimpleGenerateWithCustomDomainWithMultipleLC() throws Exception {
         File muleXmlSimple = simpleGeneration("simple", "custom-domain-multiple-lc/mule-domain-config.xml", null);
         assertTrue(muleXmlSimple.exists());
@@ -177,6 +273,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testSimpleGenerateWithEmptyDomainWithOldParser() throws Exception
+    {
+        testSimpleGenerateWithEmptyDomain();
+    }
+
+    @Test
+    public void testSimpleGenerateWithEmptyDomainWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testSimpleGenerateWithEmptyDomain();
+    }
+
     public void testSimpleGenerateWithEmptyDomain() throws Exception {
         File muleXmlSimple = simpleGeneration("simple", "empty-domain/mule-domain-config.xml", null);
         assertTrue(muleXmlSimple.exists());
@@ -184,6 +292,19 @@ public class ScaffolderTest {
         assertEquals(1, countOccurences(s, "<http:listener-config"));
         assertEquals(1, countOccurences(s, "get:/:simple-config"));
         assertEquals(1, countOccurences(s, "get:/pet:simple-config"));
+    }
+
+    @Test
+    public void testTwoResourceGenerateWithOldParser() throws Exception
+    {
+        testTwoResourceGenerate();
+    }
+
+    @Test
+    public void testTwoResourceGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testTwoResourceGenerate();
     }
 
     @Test
@@ -200,6 +321,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testNestedGenerateWithOldParser() throws Exception
+    {
+        testNestedGenerate();
+    }
+
+    @Test
+    public void testNestedGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testNestedGenerate();
+    }
+
     public void testNestedGenerate() throws Exception {
         File muleXmlSimple = simpleGeneration("nested", null, null);
         assertTrue(muleXmlSimple.exists());
@@ -212,6 +345,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testNoNameGenerateWithOldParser() throws Exception
+    {
+        testNoNameGenerate();
+    }
+
+    @Test
+    public void testNoNameGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testNoNameGenerate();
+    }
+
     public void testNoNameGenerate() throws Exception {
         File muleXmlSimple = simpleGeneration("no-name", null, null);
         assertTrue(muleXmlSimple.exists());
@@ -221,6 +366,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testExampleGenerateWithOldParser() throws Exception
+    {
+        testExampleGenerate();
+    }
+
+    @Test
+    public void testExampleGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testExampleGenerate();
+    }
+
     public void testExampleGenerate() throws Exception {
         File muleXmlSimple = simpleGeneration("example", null, null);
         assertTrue(muleXmlSimple.exists());
@@ -230,6 +387,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistsWithExtensionDisabledWithOldParser() throws Exception
+    {
+        testAlreadyExistsWithExtensionDisabled();
+    }
+
+    @Test
+    public void testAlreadyExistsWithExtensionDisabledWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsWithExtensionDisabled();
+    }
+
     public void testAlreadyExistsWithExtensionDisabled() throws Exception
     {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing-extension/simple.raml"));
@@ -250,6 +419,19 @@ public class ScaffolderTest {
         assertEquals(1, countOccurences(s, "post:/pet"));
         assertEquals(1, countOccurences(s, "get:/\""));
         assertEquals(1, countOccurences(s, "extensionEnabled=\"false\""));
+    }
+
+    @Test
+    public void testAlreadyExistsWithExtensionEnabledWithOldParser() throws Exception
+    {
+        testAlreadyExistsWithExtensionEnabled();
+    }
+
+    @Test
+    public void testAlreadyExistsWithExtensionEnabledWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsWithExtensionEnabled();
     }
 
     @Test
@@ -276,6 +458,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistsWithExtensionNotPresentWithOldParser() throws Exception
+    {
+        testAlreadyExistsWithExtensionNotPresent();
+    }
+
+    @Test
+    public void testAlreadyExistsWithExtensionNotPresentWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsWithExtensionNotPresent();
+    }
+
     public void testAlreadyExistsWithExtensionNotPresent() throws Exception
     {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing-extension/simple.raml"));
@@ -299,6 +493,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistsGenerateWithOldParser() throws Exception
+    {
+        testAlreadyExistsGenerate();
+    }
+
+    @Test
+    public void testAlreadyExistsGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsGenerate();
+    }
+
     public void testAlreadyExistsGenerate() throws Exception {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing/simple.raml"));
         File xmlFile = getFile("scaffolder-existing/simple.xml");
@@ -320,6 +526,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistsGenerateWithCustomDomainWithOldParser() throws Exception
+    {
+        testAlreadyExistsGenerateWithCustomDomain();
+    }
+
+    @Test
+    public void testAlreadyExistsGenerateWithCustomDomainWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsGenerateWithCustomDomain();
+    }
+
     public void testAlreadyExistsGenerateWithCustomDomain() throws Exception {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing-custom-lc/simple.raml"));
         File xmlFile = getFile("scaffolder-existing-custom-lc/simple.xml");
@@ -341,6 +559,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistsGenerateWithCustomAndNormalLCWithOldParser() throws Exception
+    {
+        testAlreadyExistsGenerateWithCustomAndNormalLC();
+    }
+
+    @Test
+    public void testAlreadyExistsGenerateWithCustomAndNormalLCWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsGenerateWithCustomAndNormalLC();
+    }
+
     public void testAlreadyExistsGenerateWithCustomAndNormalLC() throws Exception {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing-custom-and-normal-lc/leagues-custom-normal-lc.raml"));
         File xmlFile = getFile("scaffolder-existing-custom-and-normal-lc/leagues-custom-normal-lc.xml");
@@ -363,6 +593,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistsOldGenerateWithOldParser() throws Exception
+    {
+        testAlreadyExistsOldGenerate();
+    }
+
+    @Test
+    public void testAlreadyExistsOldGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsOldGenerate();
+    }
+
     public void testAlreadyExistsOldGenerate() throws Exception {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing-old/simple.raml"));
         File xmlFile = getFile("scaffolder-existing-old/simple.xml");
@@ -383,6 +625,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testAlreadyExistingMuleConfigWithApikitRouterWithOldParser() throws Exception
+    {
+        testAlreadyExistingMuleConfigWithApikitRouter();
+    }
+
+    @Test
+    public void testAlreadyExistingMuleConfigWithApikitRouterWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistingMuleConfigWithApikitRouter();
+    }
+
     public void testAlreadyExistingMuleConfigWithApikitRouter() throws Exception {
         List<File> ramls = Arrays.asList(getFile("scaffolder-existing/simple.raml"));
         File xmlFile = getFile("scaffolder-existing/mule-config-no-api-flows.xml");
@@ -404,6 +658,19 @@ public class ScaffolderTest {
         Collection<File> newXmlConfigs = FileUtils.listFiles(muleXmlOut, new String[] {"xml"}, true);
         assertEquals(0, newXmlConfigs.size());
         assertEquals(0, countOccurences(s, "extensionEnabled"));
+    }
+
+    @Test
+    public void testAlreadyExistsOldWithAddressGenerateWithOldParser() throws Exception
+    {
+        testAlreadyExistsOldWithAddressGenerate();
+    }
+
+    @Test
+    public void testAlreadyExistsOldWithAddressGenerateWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testAlreadyExistsOldWithAddressGenerate();
     }
 
     @Test
@@ -446,6 +713,18 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void testMultipleMimeTypesWithoutNamedConfigWithOldParser() throws Exception
+    {
+        testMultipleMimeTypesWithoutNamedConfig();
+    }
+
+    @Test
+    public void testMultipleMimeTypesWithoutNamedConfigWithNewParser() throws Exception
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        testMultipleMimeTypesWithoutNamedConfig();
+    }
+
     public void testMultipleMimeTypesWithoutNamedConfig() throws Exception {
         List<File> ramls = Arrays.asList(getFile("scaffolder/multipleMimeTypes.raml"));
         File muleXmlOut = folder.newFolder("scaffolder");
@@ -468,7 +747,13 @@ public class ScaffolderTest {
     }
 
     @Test
-    public void testMultipleMimeTypes() throws Exception {
+    public void testMultipleMimeTypesWithOldParser() throws Exception {
+        testMultipleMimeTypes("multipleMimeTypes");
+    }
+
+    @Test
+    public void testMultipleMimeTypesWithNewParser() throws Exception {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
         testMultipleMimeTypes("multipleMimeTypes");
     }
 
@@ -505,6 +790,16 @@ public class ScaffolderTest {
     }
 
     @Test
+    public void doubleRootRamlWithOldParser() throws Exception {
+        doubleRootRaml();
+    }
+
+    @Test
+    public void doubleRootRamlWithNewParser() throws Exception {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        doubleRootRaml();
+    }
+
     public void doubleRootRaml() throws Exception
     {
         List<File> ramls = Arrays.asList(getFile("double-root-raml/simple.raml"), getFile("double-root-raml/two.raml"));
@@ -570,7 +865,7 @@ public class ScaffolderTest {
         file.createNewFile();
         InputStream resourceAsStream = ScaffolderTest.class.getClassLoader().getResourceAsStream(s);
         IOUtils.copy(resourceAsStream,
-                new FileOutputStream(file));
+                     new FileOutputStream(file));
         return file;
     }
 
@@ -610,5 +905,11 @@ public class ScaffolderTest {
         scaffolder.run();
 
         return muleXmlOut;
+    }
+
+    @After
+    public void after()
+    {
+        System.clearProperty(ParserV2Utils.PARSER_V2_PROPERTY);
     }
 }

--- a/apikit-tools/apikit-scaffolder/src/test/java/org/mule/tools/apikit/ScaffolderTest.java
+++ b/apikit-tools/apikit-scaffolder/src/test/java/org/mule/tools/apikit/ScaffolderTest.java
@@ -171,7 +171,7 @@ public class ScaffolderTest {
         assertTrue(muleXmlSimple.exists());
         String s = IOUtils.toString(new FileInputStream(muleXmlSimple));
         assertEquals(0, countOccurences(s, "<http:listener-config"));
-        assertEquals(1, countOccurences(s, "config-ref=\"http-lc-0.0.0.0-8080\""));
+        assertEquals(1, countOccurences(s, "config-ref=\"abcd\""));
         assertEquals(1, countOccurences(s, "get:/:simple-config"));
         assertEquals(1, countOccurences(s, "get:/pet:simple-config"));
     }

--- a/apikit-tools/apikit-scaffolder/src/test/java/org/mule/tools/apikit/input/RAMLFilesParserTest.java
+++ b/apikit-tools/apikit-scaffolder/src/test/java/org/mule/tools/apikit/input/RAMLFilesParserTest.java
@@ -19,6 +19,8 @@ import java.util.Set;
 
 import junit.framework.Assert;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Predicate;
 import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
 import org.mule.tools.apikit.model.APIFactory;
@@ -48,15 +50,33 @@ public class RAMLFilesParserTest
         assertNotNull(entries);
         assertEquals(2, entries.size());
         Set<ResourceActionMimeTypeTriplet> ramlEntries = entries.keySet();
-        ResourceActionMimeTypeTriplet triplet = ramlEntries.iterator().next();
-        Assert.assertEquals("/api/pet", triplet.getUri());
-        Assert.assertEquals("GET", triplet.getVerb());
-        Assert.assertEquals("/api",triplet.getApi().getPath());
-        Assert.assertNotNull(triplet.getApi().getHttpListenerConfig());
+        ResourceActionMimeTypeTriplet triplet = (ResourceActionMimeTypeTriplet)CollectionUtils.find(ramlEntries, new Predicate()
+        {
+            @Override
+            public boolean evaluate(Object property)
+            {
+                ResourceActionMimeTypeTriplet triplet = ((ResourceActionMimeTypeTriplet)property);
+                return "/api/".equals(triplet.getUri()) && "GET".equals(triplet.getVerb()) && "/api".equals(triplet.getApi().getPath());
+            }
+        });
         Assert.assertEquals("0.0.0.0", triplet.getApi().getHttpListenerConfig().getHost());
         Assert.assertEquals("8081", triplet.getApi().getHttpListenerConfig().getPort());
         Assert.assertEquals("/", triplet.getApi().getHttpListenerConfig().getBasePath());
         Assert.assertEquals("hello-httpListenerConfig",triplet.getApi().getHttpListenerConfig().getName());
+        ResourceActionMimeTypeTriplet triplet2 = (ResourceActionMimeTypeTriplet)CollectionUtils.find(ramlEntries, new Predicate()
+        {
+            @Override
+            public boolean evaluate(Object property)
+            {
+                ResourceActionMimeTypeTriplet triplet = ((ResourceActionMimeTypeTriplet)property);
+                return "/api/pet".equals(triplet.getUri()) && "GET".equals(triplet.getVerb()) && "/api".equals(triplet.getApi().getPath());
+            }
+        });
+        Assert.assertEquals("0.0.0.0", triplet2.getApi().getHttpListenerConfig().getHost());
+        Assert.assertEquals("8081", triplet2.getApi().getHttpListenerConfig().getPort());
+        Assert.assertEquals("/", triplet2.getApi().getHttpListenerConfig().getBasePath());
+        Assert.assertEquals("hello-httpListenerConfig",triplet2.getApi().getHttpListenerConfig().getName());
+
     }
 
     @Test

--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/ParserService.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/ParserService.java
@@ -10,6 +10,7 @@ import org.mule.module.apikit.injector.RamlUpdater;
 import org.mule.module.apikit.parser.ParserWrapper;
 import org.mule.module.apikit.parser.ParserWrapperV1;
 import org.mule.module.apikit.parser.ParserWrapperV2;
+import org.mule.raml.implv2.ParserV2Utils;
 import org.mule.raml.interfaces.model.IRaml;
 
 import java.io.InputStream;
@@ -25,7 +26,6 @@ import org.slf4j.LoggerFactory;
 public class ParserService
 {
 
-    private static final String PARSER_V2_PROPERTY = "apikit.raml.parser.v2";
     private static final Logger logger = LoggerFactory.getLogger(ParserService.class);
 
     private final String ramlPath;
@@ -60,19 +60,11 @@ public class ParserService
 
     private void checkParserVersion()
     {
-        String property = System.getProperty(PARSER_V2_PROPERTY);
-        if (property != null && Boolean.valueOf(property))
+        InputStream content = resourceLoaderV2.fetchResource(ramlPath);
+        if (content != null)
         {
-            parserV2 = true;
-        }
-        else
-        {
-            InputStream content = resourceLoaderV2.fetchResource(ramlPath);
-            if (content != null)
-            {
-                String dump = StreamUtils.toString(content);
-                parserV2 = dump.startsWith("#%RAML 1.0");
-            }
+            String dump = StreamUtils.toString(content);
+            parserV2 = ParserV2Utils.useParserV2(dump);
         }
         logger.debug("Using parser " + (parserV2 ? "V2" : "V1"));
     }

--- a/parser-wrapper/interface-impl-v1/src/main/java/org/mule/raml/implv1/ParserV1Utils.java
+++ b/parser-wrapper/interface-impl-v1/src/main/java/org/mule/raml/implv1/ParserV1Utils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.raml.implv1;
+
+import org.mule.raml.implv1.parser.visitor.RamlDocumentBuilderImpl;
+import org.mule.raml.implv1.parser.visitor.RamlValidationServiceImpl;
+import org.mule.raml.interfaces.model.IRaml;
+import org.mule.raml.interfaces.parser.rule.IValidationResult;
+import org.mule.raml.interfaces.parser.visitor.IRamlDocumentBuilder;
+import org.mule.raml.interfaces.parser.visitor.IRamlValidationService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParserV1Utils
+{
+    public static List<String> validate(String filePath, String resource, String resourceContent)
+    {
+        List<String> errorsList = new ArrayList<>();
+        IRamlDocumentBuilder ramlDocumentBuilder = new RamlDocumentBuilderImpl();
+        ramlDocumentBuilder.addPathLookupFirst(filePath);
+        IRamlValidationService validationService = new RamlValidationServiceImpl(ramlDocumentBuilder);
+        IRamlValidationService result = validationService.validate(resourceContent, resource);
+        for (IValidationResult validationResult : result.getErrors())
+        {
+            errorsList.add(validationResult.getMessage());
+        }
+        return  errorsList;
+    }
+
+    public static IRaml build(String content, String resourceLocation)
+    {
+        IRamlDocumentBuilder ramlDocumentBuilder = new RamlDocumentBuilderImpl();
+        ramlDocumentBuilder.addPathLookupFirst(resourceLocation);
+        return ramlDocumentBuilder.build(content, resourceLocation);
+    }
+}

--- a/parser-wrapper/interface-impl-v1/src/main/java/org/mule/raml/implv1/parser/visitor/RamlDocumentBuilderImpl.java
+++ b/parser-wrapper/interface-impl-v1/src/main/java/org/mule/raml/implv1/parser/visitor/RamlDocumentBuilderImpl.java
@@ -40,29 +40,6 @@ public class RamlDocumentBuilderImpl implements IRamlDocumentBuilder
         return new RamlImplV1(ramlDocumentBuilder.build(resourceLocation));
     }
 
-    //public IRamlDocumentBuilder addPathLookup(String path)
-    //{
-    //    ResourceLoader loader = ramlDocumentBuilder.getResourceLoader();
-    //    loader = new CompositeResourceLoader(loader, new FileResourceLoader(path));
-    //    ramlDocumentBuilder = new RamlDocumentBuilder(loader);
-    //    return this;
-    //}
-
-    //public IRamlDocumentBuilder addClassPathLookup()
-    //{
-    //    ResourceLoader loader = ramlDocumentBuilder.getResourceLoader();
-    //    loader = new CompositeResourceLoader(loader, new ClassPathResourceLoader());
-    //    ramlDocumentBuilder = new RamlDocumentBuilder(loader);
-    //    return this;
-    //}
-
-    //public IRamlDocumentBuilder setRamlUrlLookup()
-    //{
-    //    ResourceLoader loader = new RamlUrlResourceLoader();
-    //    ramlDocumentBuilder = new RamlDocumentBuilder(loader);
-    //    return this;
-    //}
-
     public IRamlDocumentBuilder addPathLookupFirst(String path)
     {
         ResourceLoader loader = ramlDocumentBuilder.getResourceLoader();

--- a/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/ParserV2Utils.java
+++ b/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/ParserV2Utils.java
@@ -20,6 +20,7 @@ import org.raml.v2.api.model.common.ValidationResult;
 
 public class ParserV2Utils
 {
+    public static final String PARSER_V2_PROPERTY = "apikit.raml.parser.v2";
 
     public static IRaml build(ResourceLoader resourceLoader, String ramlPath)
     {
@@ -68,5 +69,18 @@ public class ParserV2Utils
     public static List<String> validate(ResourceLoader resourceLoader, String ramlPath)
     {
         return validate(resourceLoader, ramlPath, null);
+    }
+
+    public static boolean useParserV2(String content)
+    {
+        String property = System.getProperty(PARSER_V2_PROPERTY);
+        if (property != null && Boolean.valueOf(property))
+        {
+            return true;
+        }
+        else
+        {
+            return content.startsWith("#%RAML 1.0");
+        }
     }
 }

--- a/parser-wrapper/interface-impl-v2/src/test/java/org/mule/raml/implv2/ParserV2UtilsTestCase.java
+++ b/parser-wrapper/interface-impl-v2/src/test/java/org/mule/raml/implv2/ParserV2UtilsTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.raml.implv2;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class ParserV2UtilsTestCase
+{
+
+    @Test
+    public void chooseWhichParserToUseWithoutSystemProperty()
+    {
+        assertTrue(ParserV2Utils.useParserV2("#%RAML 1.0 this is an api definition"));
+        assertFalse(ParserV2Utils.useParserV2("#%RAML 0.8 this is an api definition"));
+    }
+
+    @Test
+    public void chooseWhichParserToUseWithSystemPropertyInTrue()
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "true");
+        assertTrue(ParserV2Utils.useParserV2("#%RAML 0.8 this is an api definition"));
+        assertTrue(ParserV2Utils.useParserV2("#%RAML 1.0 this is an api definition"));
+    }
+
+    @Test
+    public void chooseWhichParserToUseWithSystemPropertyInFalse()
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "false");
+        assertTrue(ParserV2Utils.useParserV2("#%RAML 1.0 this is an api definition"));
+        assertFalse(ParserV2Utils.useParserV2("#%RAML 0.8 this is an api definition"));
+    }
+
+    @Test
+    public void chooseWhichParserToUseWithSystemPropertyInANonBooleanValue()
+    {
+        System.setProperty(ParserV2Utils.PARSER_V2_PROPERTY, "non-boolean-value");
+        assertTrue(ParserV2Utils.useParserV2("#%RAML 1.0 this is an api definition"));
+        assertFalse(ParserV2Utils.useParserV2("#%RAML 0.8 this is an api definition"));
+    }
+
+    @After
+    public void after()
+    {
+        System.clearProperty(ParserV2Utils.PARSER_V2_PROPERTY);
+    }
+}

--- a/parser-wrapper/parser-interface/src/main/java/org/mule/raml/interfaces/parser/visitor/IRamlDocumentBuilder.java
+++ b/parser-wrapper/parser-interface/src/main/java/org/mule/raml/interfaces/parser/visitor/IRamlDocumentBuilder.java
@@ -15,12 +15,6 @@ public interface IRamlDocumentBuilder
 
     IRaml build(String resourceLocation);
 
-    //IRamlDocumentBuilder addPathLookup(String path);
-    //
-    //IRamlDocumentBuilder addClassPathLookup();
-    //
-    //IRamlDocumentBuilder setRamlUrlLookup();
-
     IRamlDocumentBuilder addPathLookupFirst(String path);
 
     IRamlDocumentBuilder addClassPathLookup(ClassLoader customClassLoader);


### PR DESCRIPTION
Fixing tests that were failing using Java 8