### PR TITLE
Parser interface example methods for parameters

### DIFF
--- a/parser-wrapper/interface-impl-v1/src/main/java/org/mule/raml/implv1/model/parameter/ParameterImpl.java
+++ b/parser-wrapper/interface-impl-v1/src/main/java/org/mule/raml/implv1/model/parameter/ParameterImpl.java
@@ -9,6 +9,9 @@ package org.mule.raml.implv1.model.parameter;
 import org.mule.raml.interfaces.model.parameter.IParameter;
 import org.raml.model.parameter.AbstractParam;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ParameterImpl implements IParameter
 {
 
@@ -58,6 +61,22 @@ public class ParameterImpl implements IParameter
     public String getDescription()
     {
         return parameter.getDescription();
+    }
+
+    public String getExample()
+    {
+        return parameter.getExample();
+    }
+
+    @Override
+    public String getExampleName()
+    {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getExamples() {
+        return new HashMap<>();
     }
 
     public Object getInstance()

--- a/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v08/model/ActionImpl.java
+++ b/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v08/model/ActionImpl.java
@@ -14,6 +14,7 @@ import org.mule.raml.interfaces.model.IResponse;
 import org.mule.raml.interfaces.model.ISecurityReference;
 import org.mule.raml.interfaces.model.parameter.IParameter;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import java.util.Map;
 import org.raml.v2.api.model.v08.bodies.BodyLike;
 import org.raml.v2.api.model.v08.bodies.Response;
 import org.raml.v2.api.model.v08.methods.Method;
+import org.raml.v2.api.model.v08.parameters.Parameter;
 
 public class ActionImpl implements IAction
 {
@@ -81,13 +83,23 @@ public class ActionImpl implements IAction
     @Override
     public Map<String, IParameter> getQueryParameters()
     {
-        throw new UnsupportedOperationException();
+        Map<String, IParameter> result = new HashMap<>();
+        for (Parameter parameter : method.queryParameters())
+        {
+            result.put(parameter.name(), new ParameterImpl(parameter));
+        }
+        return result;
     }
 
     @Override
     public Map<String, IParameter> getHeaders()
     {
-        throw new UnsupportedOperationException();
+        Map<String, IParameter> result = new HashMap<>();
+        for (Parameter parameter : method.headers())
+        {
+            result.put(parameter.name(), new ParameterImpl(parameter));
+        }
+        return result;
     }
 
     @Override

--- a/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v08/model/ParameterImpl.java
+++ b/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v08/model/ParameterImpl.java
@@ -10,6 +10,9 @@ import org.mule.raml.interfaces.model.parameter.IParameter;
 
 import org.raml.v2.api.model.v08.parameters.Parameter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ParameterImpl implements IParameter
 {
 
@@ -23,13 +26,17 @@ public class ParameterImpl implements IParameter
     @Override
     public boolean isRequired()
     {
-        throw new UnsupportedOperationException();
+        return parameter.required();
     }
 
     @Override
     public String getDefaultValue()
     {
-        throw new UnsupportedOperationException();
+        if(parameter.defaultValue() == null)
+        {
+            return null;
+        }
+        return parameter.defaultValue().toString();
     }
 
     @Override
@@ -67,6 +74,26 @@ public class ParameterImpl implements IParameter
     public String getDescription()
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getExample()
+    {
+        return parameter.example();
+    }
+
+    @Override
+    public String getExampleName()
+    {
+        // only available in RAML 1.0+
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getExamples()
+    {
+        // only available in RAML 1.0+
+        return new HashMap<>();
     }
 
     @Override

--- a/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v08/model/ResourceImpl.java
+++ b/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v08/model/ResourceImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.raml.v2.api.model.v08.methods.Method;
+import org.raml.v2.api.model.v08.parameters.Parameter;
 import org.raml.v2.api.model.v08.resources.Resource;
 
 public class ResourceImpl implements IResource
@@ -91,7 +92,17 @@ public class ResourceImpl implements IResource
     @Override
     public Map<String, IParameter> getResolvedUriParameters()
     {
-        throw new UnsupportedOperationException();
+        Map<String, IParameter> result = new HashMap<>();
+        Resource current = resource;
+        while (current != null)
+        {
+            for (Parameter parameter : current.uriParameters())
+            {
+                result.put(parameter.name(), new ParameterImpl(parameter));
+            }
+            current = current.parentResource();
+        }
+        return result;
     }
 
     @Override

--- a/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v10/model/ParameterImpl.java
+++ b/parser-wrapper/interface-impl-v2/src/main/java/org/mule/raml/implv2/v10/model/ParameterImpl.java
@@ -7,12 +7,14 @@
 package org.mule.raml.implv2.v10.model;
 
 import org.mule.raml.interfaces.model.parameter.IParameter;
-
-import java.util.List;
-
 import org.raml.v2.api.model.common.ValidationResult;
 import org.raml.v2.api.model.v10.datamodel.ArrayTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.ExampleSpec;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ParameterImpl implements IParameter
 {
@@ -74,6 +76,38 @@ public class ParameterImpl implements IParameter
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String getExample()
+    {
+        if(typeDeclaration.example() == null)
+        {
+            return null;
+        }
+        return typeDeclaration.example().value();
+    }
+
+    @Override
+    public String getExampleName()
+    {
+        if(typeDeclaration.example() == null)
+        {
+            return null;
+        }
+        return typeDeclaration.example().name();
+    }
+
+    @Override
+    public Map<String, String> getExamples()
+    {
+        Map<String, String> examples = new LinkedHashMap<>();
+        for(ExampleSpec example : typeDeclaration.examples())
+        {
+            examples.put(example.name(), example.value());
+        }
+        return examples;
+    }
+
 
     @Override
     public Object getInstance()

--- a/parser-wrapper/parser-interface/src/main/java/org/mule/raml/interfaces/model/parameter/IParameter.java
+++ b/parser-wrapper/parser-interface/src/main/java/org/mule/raml/interfaces/model/parameter/IParameter.java
@@ -6,6 +6,8 @@
  */
 package org.mule.raml.interfaces.model.parameter;
 
+import java.util.Map;
+
 public interface IParameter
 {
     boolean isRequired();
@@ -16,5 +18,8 @@ public interface IParameter
     String message(String value);
     String getDisplayName();
     String getDescription();
+    String getExample();
+    String getExampleName();
+    Map<String, String> getExamples();
     Object getInstance();
 }


### PR DESCRIPTION
Example/Examples getters for parameters
QueryParameters getter for ActionImpl in V8
Headers getter for ActionImpl in V8
DefaultValue getter for ParameterImpl in V8
Required getter in ParameterImpl in V8
ResolvedUriParameters getter in ResourceImpl in V8
