### PR TITLE
APIKIT-780: ResourceNotFoundException when RAML file is in subdirectory

### DIFF
--- a/mule-module-apikit/src/main/java/org/mule/module/apikit/ConsoleHandler.java
+++ b/mule-module-apikit/src/main/java/org/mule/module/apikit/ConsoleHandler.java
@@ -115,7 +115,11 @@ public class ConsoleHandler implements MessageProcessor
             File apiResource = new File(configuration.getAppHome(), "/" + DEFAULT_API_RESOURCES_PATH + ramlLocation);
             if (apiResource.isFile())
             {
-                return DEFAULT_API_RESOURCES_PATH + "?" + RAML_QUERY_STRING;
+                if (ramlLocation.contains("/"))
+                {
+                    apiResourcesRelativePath += ramlLocation.substring(0, ramlLocation.lastIndexOf("/") + 1);
+                }
+                return apiResourcesRelativePath + "?" + RAML_QUERY_STRING;
             }
 
             // check if raml is in a classpath subdir

--- a/mule-module-apikit/src/test/java/org/mule/module/apikit/console/ConsoleRamlUriTestCase.java
+++ b/mule-module-apikit/src/test/java/org/mule/module/apikit/console/ConsoleRamlUriTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.apikit.console;
+
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.mule.module.apikit.Configuration;
+import org.mule.module.apikit.ConsoleHandler;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+
+public class ConsoleRamlUriTestCase
+{
+
+    private String consoleBaseUri = "http://localhost:8081/console";
+    private Configuration configuration = mock(Configuration.class);
+
+    {
+        when(configuration.isParserV2()).thenReturn(true);
+        when(configuration.getAppHome()).thenReturn(new File("src/test/resources").getAbsolutePath());
+    }
+
+    @Test
+    public void apiDirectory() throws Exception
+    {
+        when(configuration.getRaml()).thenReturn("api.raml");
+        assertThat(getApiResourcesRelativePath(getConsoleHandler()), is("api/"));
+    }
+
+    @Test
+    public void nestedApiDirecotry() throws Exception
+    {
+        when(configuration.getRaml()).thenReturn("subdir/api.raml");
+        assertThat(getApiResourcesRelativePath(getConsoleHandler()), is("api/subdir/"));
+    }
+
+    private ConsoleHandler getConsoleHandler()
+    {
+        ConsoleHandler consoleHandler = new ConsoleHandler(consoleBaseUri, configuration);
+        consoleHandler.updateRamlUri();
+        return consoleHandler;
+    }
+
+    private String getApiResourcesRelativePath(ConsoleHandler consoleHandler) throws NoSuchFieldException, IllegalAccessException
+    {
+        Field f = consoleHandler.getClass().getDeclaredField("apiResourcesRelativePath");
+        f.setAccessible(true);
+        return (String) f.get(consoleHandler);
+    }
+}

--- a/mule-module-apikit/src/test/resources/api/api.raml
+++ b/mule-module-apikit/src/test/resources/api/api.raml
@@ -1,0 +1,2 @@
+#%RAML 1.0
+title: mock raml file to test api resources inside root api directory

--- a/mule-module-apikit/src/test/resources/api/subdir/api.raml
+++ b/mule-module-apikit/src/test/resources/api/subdir/api.raml
@@ -1,0 +1,2 @@
+#%RAML 1.0
+title: mock raml file to test api resources inside subdirectories


### PR DESCRIPTION
inside src/main/api