### PR TITLE
New java raml parser version released 1.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.raml</groupId>
                 <artifactId>raml-parser-2</artifactId>
-                <version>1.0.17-SNAPSHOT</version>
+                <version>1.0.18-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId> org.slf4j</groupId>


### PR DESCRIPTION
New java raml parser version released 1.0.17, changing to 1.0.18-SNAP…SHOT