### PR TITLE
Update RAML parser to 1.0.23-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>org.raml</groupId>
                 <artifactId>raml-parser-2</artifactId>
-                <version>1.0.21-SNAPSHOT</version>
+                <version>1.0.23-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
merging this change requires updating the assembly whitelist in mule & mule-ee projects