### PR TITLE
APIKIT-1526: Metadata NPE fixed when raml is empty in config

### DIFF
--- a/mule-apikit-metadata/src/main/java/org/mule/module/apikit/metadata/raml/RamlHandler.java
+++ b/mule-apikit-metadata/src/main/java/org/mule/module/apikit/metadata/raml/RamlHandler.java
@@ -14,6 +14,7 @@ import org.mule.raml.interfaces.model.IRaml;
 
 import java.io.*;
 import java.util.Optional;
+import org.mule.runtime.core.api.util.StringUtils;
 
 import static java.lang.Boolean.getBoolean;
 import static java.lang.String.format;
@@ -34,6 +35,12 @@ public class RamlHandler {
 
   public Optional<IRaml> getRamlApi(String uri) {
     try {
+
+      if (StringUtils.isEmpty(uri)) {
+        notifier.error("RAML document is undefined.");
+        return empty();
+      }
+
       final File resource = resourceLoader.getRamlResource(uri);
 
       if (resource == null) {


### PR DESCRIPTION
 Metadata NPE fixed when raml is empty in config