### PR TITLE
Avoid creation of URLs to open streams and ask the resource loader

### DIFF
--- a/mule-apikit-tools/mule-apikit-scaffolder/pom.xml
+++ b/mule-apikit-tools/mule-apikit-scaffolder/pom.xml
@@ -21,17 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.raml</groupId>
-            <artifactId>raml-parser-interface-impl-v1</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.raml</groupId>
-            <artifactId>raml-parser-interface-impl-v2</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mule.raml</groupId>
-            <artifactId>raml-parser-interface-impl-amf</artifactId>
+            <artifactId>parser-service</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/mule-apikit-tools/mule-apikit-scaffolder/src/main/java/org/mule/tools/apikit/ScaffolderAPI.java
+++ b/mule-apikit-tools/mule-apikit-scaffolder/src/main/java/org/mule/tools/apikit/ScaffolderAPI.java
@@ -130,10 +130,10 @@ public class ScaffolderAPI {
       String dependencyResourceFormat = format(RESOURCE_FORMAT, dependency.getGroupId(), dependency.getArtifactId(),
                                                dependency.getVersion(), dependency.getClassifier(), dependency.getType(), "%s");
       InputStream exchangeJson =
-          scaffolderResourceLoader.getResource(format(dependencyResourceFormat, EXCHANGE_JSON)).toURL().openStream();
+          scaffolderResourceLoader.getResourceAsStream(format(dependencyResourceFormat, EXCHANGE_JSON));
       String rootApiFileName = APISyncUtils.getMainApi(IOUtils.toString(exchangeJson));
       String rootApiResource = format(dependencyResourceFormat, rootApiFileName);
-      InputStream rootApi = scaffolderResourceLoader.getResource(rootApiResource).toURL().openStream();
+      InputStream rootApi = scaffolderResourceLoader.getResourceAsStream(rootApiResource);
       apiSpecs.put(rootApiResource, rootApi);
     }
 

--- a/mule-apikit-tools/mule-apikit-scaffolder/src/main/java/org/mule/tools/apikit/input/RAMLFilesParser.java
+++ b/mule-apikit-tools/mule-apikit-scaffolder/src/main/java/org/mule/tools/apikit/input/RAMLFilesParser.java
@@ -104,7 +104,7 @@ public class RAMLFilesParser {
   public static RAMLFilesParser create(Log log, Map<String, InputStream> apis, APIFactory apiFactory,
                                        ScaffolderResourceLoader scaffolderResourceLoader) {
     final List<ApiRef> specs = apis.entrySet().stream()
-        .map(e -> ApiRef.create(e.getKey()))
+        .map(e -> ApiRef.create(e.getKey(), scaffolderResourceLoader))
         .collect(toList());
 
     return new RAMLFilesParser(log, specs, apiFactory, scaffolderResourceLoader);

--- a/parser-wrapper/interface-impl-amf/src/main/java/org/mule/amf/impl/loader/ProvidedResourceLoader.java
+++ b/parser-wrapper/interface-impl-amf/src/main/java/org/mule/amf/impl/loader/ProvidedResourceLoader.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.mule.raml.interfaces.loader.ResourceLoader;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 
@@ -33,9 +34,9 @@ public class ProvidedResourceLoader implements amf.client.resource.ResourceLoade
     final URI resource = resourceLoader.getResource(resourceName);
 
     if (resource != null) {
-      final String resourceAsString;
+      final InputStream stream = resourceLoader.getResourceAsStream(resourceName);
       try {
-        resourceAsString = IOUtils.toString(resource.toURL().openStream());
+        final String resourceAsString = IOUtils.toString(stream);
         final Content content = new Content(resourceAsString, resource.toString());
         future.complete(content);
       } catch (IOException e) {

--- a/parser-wrapper/raml-parser-interface/src/main/java/org/mule/raml/interfaces/loader/ResourceLoader.java
+++ b/parser-wrapper/raml-parser-interface/src/main/java/org/mule/raml/interfaces/loader/ResourceLoader.java
@@ -9,6 +9,8 @@ package org.mule.raml.interfaces.loader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
 
 /**
  * Represents a way of getting resources from the application
@@ -27,7 +29,10 @@ public interface ResourceLoader {
   default InputStream getResourceAsStream(String relativePath) {
     URI uri = getResource(relativePath);
     try {
-      return uri != null ? uri.toURL().openStream() : null;
+      URL url = uri.toURL();
+      URLConnection urlConnection = url.openConnection();
+      urlConnection.setUseCaches(false);
+      return urlConnection.getInputStream();
     } catch (IOException e) {
       return null;
     }


### PR DESCRIPTION
When using snapshots, is possible for a resource (jar) to be replaced. To read the content of that resource, we use to ask the resource loader for a stream, or create an URL and open stream. The last one, if is not specified, will cache the result and that behaviour causes some issues when a resource has been replaced.