### PR TITLE
MuleConfigGenerator.getDocument() leaks file stream

### DIFF
--- a/apikit-tools/apikit-scaffolder/src/main/java/org/mule/tools/apikit/output/MuleConfigGenerator.java
+++ b/apikit-tools/apikit-scaffolder/src/main/java/org/mule/tools/apikit/output/MuleConfigGenerator.java
@@ -173,8 +173,9 @@ public class MuleConfigGenerator {
             doc = new Document();
             doc.setRootElement(new MuleScope().generate());
         } else {
-            InputStream xmlInputStream = new FileInputStream(xmlFile);
-            doc = saxBuilder.build(xmlInputStream);
+            try (InputStream xmlInputStream = new FileInputStream(xmlFile)) {
+              doc = saxBuilder.build(xmlInputStream);
+            }
         }
         return doc;
     }


### PR DESCRIPTION
Using try-with-resources to avoid leaking a file input stream, which renders the file undeletable/unavailable on Windows.