### PR TITLE
W-13498765: Java RAML Parser -> 1.0.44-10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <allure.maven.plugin.version>2.10.0</allure.maven.plugin.version>
         
         <raml.parser.v1.version>0.8.47</raml.parser.v1.version>
-        <raml.parser.v2.version>1.0.44-6</raml.parser.v2.version>
+        <raml.parser.v2.version>1.0.44-10</raml.parser.v2.version>
         <jackson.version>2.14.0-rc1</jackson.version>
     </properties>
 


### PR DESCRIPTION
On October of 2022, a [critical flaw](https://nvd.nist.gov/vuln/detail/CVE-2022-1471) was found in the SnakeYAML package, which allowed an attacker to benefit from remote code execution by sending malicious YAML content and this content being deserialized by the constructor. Finally, in February 2023, the SnakeYAML 2.0 release was pushed that resolves this flaw, also referred to as [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471). Let’s break down how this version can help you resolve this critical flaw.